### PR TITLE
Update recipe for gridfill v1.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.0" %}
+{% set version = "1.0.0" %}
 
 package:
     name: gridfill
@@ -7,22 +7,20 @@ package:
 source:
     fn: v{{ version }}.tar.gz
     url: https://github.com/ajdawson/gridfill/archive/v{{ version }}.tar.gz
-    md5: 4d26437253b77d756e5b37e516c63b51
+    md5: 7258701d8296f974268e634ea09ed673
 
 build:
     number: 0
-    skip: True  # [win and py3k or win64]
 
 requirements:
     build:
         - python
+        - setuptools
+        - cython
         - numpy x.x
-        - mingwpy  # [win]
-        - gcc  # [unix]
     run:
         - python
         - numpy x.x
-        - libgcc  # [unix]
 
 test:
     requires:

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,11 @@
+:: Run the test suite in its own directory
+::
+
+mkdir gftests
+cd gftests
+if %ERRORLEVEL% GEQ 1 exit 1
+nosetests -sv gridfill
+set stat=%ERRORLEVEL%
+cd ..
+rmdir /s /q gftests
+exit %stat%

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Run the test suite in its own directory.
+#
+
+mkdir gftests && cd gftests || exit 1
+nosetests -sv gridfill
+stat=$?
+cd .. && rm -rf gftests || exit 2
+exit $stat


### PR DESCRIPTION
This version of gridfill uses a Cython backend instead of Fortran. I've also added test scripts to make sure the built package is working properly (a better test than just importing it).